### PR TITLE
Fix NetID inversion for ReJoin0or2

### DIFF
--- a/src/mac/LoRaMacSerializer.c
+++ b/src/mac/LoRaMacSerializer.c
@@ -107,7 +107,7 @@ LoRaMacSerializerStatus_t LoRaMacSerializerReJoinType0or2( LoRaMacMessageReJoinT
 
     macMsg->Buffer[bufItr++] = macMsg->ReJoinType;
 
-    memcpyr( &macMsg->Buffer[bufItr], macMsg->NetID, LORAMAC_NET_ID_FIELD_SIZE );
+    memcpy1( &macMsg->Buffer[bufItr], macMsg->NetID, LORAMAC_NET_ID_FIELD_SIZE );
     bufItr += LORAMAC_NET_ID_FIELD_SIZE;
 
     memcpyr( &macMsg->Buffer[bufItr], macMsg->DevEUI, LORAMAC_DEV_EUI_FIELD_SIZE );


### PR DESCRIPTION
In the feature branch in the LoRaMac.c the function SendReJoinReq already has the NetID set correctly for transmission(little endian)
![image](https://user-images.githubusercontent.com/42280888/54929498-f3850780-4f15-11e9-965f-14a0f7a838f7.png)

 this copying in reversed order caused the NetID to be inverted sending the wrong NetID in ReJoinReq types 0 and 2